### PR TITLE
Use a temp git branch to fix the Jenkins Build

### DIFF
--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -4,7 +4,7 @@ node {
 
     sh 'mkdir -p ./_ci_repository'
     dir('./_ci_repository') {
-        git url: 'https://github.com/ihiji/ci', credentialsId: 'ihiji-chef-api-key-as-uname-pw'
+        git url: 'https://github.com/zsock/ci', credentialsId: 'ihiji-chef-api-key-as-uname-pw'
         dir ('./jenkins') {
             python = fileLoader.load('./python.groovy')
             python.repo = 'django-fields'


### PR DESCRIPTION
We are going to point to a fork instead of the master as currently
we are locked to one hardcoded virtual env for python.  This new
fork is also hardcoded but the venv that is required.  Going
forward we need this to be dynamic in some way.