### PR TITLE
Removed 'moving target' master environment from dependency list.

### DIFF
--- a/tox.ini
+++ b/tox.ini
@@ -2,13 +2,13 @@
 envlist =
        django18,
        django19,
-       django110,
-       django{master}
+       django110
+
 
 [testenv]
 deps =
         django18: Django==1.8.16
         django19: Django==1.9.11
         django110: Django==1.10.3
-        djangomaster: https://github.com/django/django/archive/master.tar.gz
+
 commands = python setup.py test


### PR DESCRIPTION
Keeping tests passing for master breaks compatibility with the
version of django being supported by the project this dependency
is being used in.